### PR TITLE
chore: rename project to unscoped opencode-claude-skill-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-skill-sync
+# opencode-claude-skill-sync
 
 Automatically syncs OpenCode plugin skills to Claude Code so they're available in every session—no manual setup required.
 
@@ -8,7 +8,7 @@ Add the plugin to your OpenCode configuration file (`opencode.json`):
 
 ```json
 {
-  "plugin": ["@opencode-ai/claude-skill-sync"]
+  "plugin": ["opencode-claude-skill-sync"]
 }
 ```
 
@@ -20,7 +20,7 @@ To lock a specific version:
 
 ```json
 {
-  "plugin": ["@opencode-ai/claude-skill-sync@1.0.0"]
+  "plugin": ["opencode-claude-skill-sync@1.0.0"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# opencode-claude-skill-sync
+# @jannniiiii/opencode-claude-skill-sync
 
 Automatically syncs OpenCode plugin skills to Claude Code so they're available in every session—no manual setup required.
 
@@ -8,7 +8,7 @@ Add the plugin to your OpenCode configuration file (`opencode.json`):
 
 ```json
 {
-  "plugin": ["opencode-claude-skill-sync"]
+  "plugin": ["@jannniiiii/opencode-claude-skill-sync"]
 }
 ```
 
@@ -20,7 +20,7 @@ To lock a specific version:
 
 ```json
 {
-  "plugin": ["opencode-claude-skill-sync@1.0.0"]
+  "plugin": ["@jannniiiii/opencode-claude-skill-sync@1.0.0"]
 }
 ```
 
@@ -66,6 +66,12 @@ Clone the repository and install dependencies:
 git clone https://github.com/anomalyco/opencode-claude-skill-sync.git
 cd opencode-claude-skill-sync
 npm install
+```
+
+Or install from npm:
+
+```bash
+npm install @jannniiiii/opencode-claude-skill-sync
 ```
 
 ### Scripts

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opencode-claude-skill-sync",
+  "name": "@jannniiiii/opencode-claude-skill-sync",
   "version": "1.0.0",
   "description": "Automatically syncs OpenCode plugin skills to Claude Code ~/.claude/skills directory",
   "type": "module",
@@ -48,7 +48,7 @@
     "claude",
     "sync"
   ],
-  "author": "OpenCode Contributors",
+  "author": "jannniiiii",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@opencode-ai/claude-skill-sync",
+  "name": "opencode-claude-skill-sync",
   "version": "1.0.0",
   "description": "Automatically syncs OpenCode plugin skills to Claude Code ~/.claude/skills directory",
   "type": "module",


### PR DESCRIPTION
Finalizes project renaming from scoped (@randomm/opencode-claude-skill-sync) to unscoped (opencode-claude-skill-sync) naming convention.