### PR TITLE
fix: add missing release dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitest/coverage-v8": "^1.0.0",
+        "conventional-changelog-conventionalcommits": "^9.1.0",
         "eslint": "^8.0.0",
         "prettier": "^3.1.0",
         "semantic-release": "^24.0.0",
@@ -2733,6 +2734,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.1.0.tgz",
+      "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitest/coverage-v8": "^1.0.0",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "eslint": "^8.0.0",
     "prettier": "^3.1.0",
     "semantic-release": "^24.0.0",


### PR DESCRIPTION
## Summary
Adds the missing `conventional-changelog-conventionalcommits` dependency that is required by the release workflow.

## Error Fixed
Resolves the `Cannot find module 'conventional-changelog-conventionalcommits'` error that occurred during the release process.

## Changes
- Added `conventional-changelog-conventionalcommits` to package.json dependencies
- Updated package-lock.json with the new dependency