### PR TITLE
fix: sync skills to correct OpenCode directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,12 +235,13 @@ async function findSkillsInMarketplaces(
 async function syncSkills(client: PluginInput["client"]): Promise<void> {
   const home = homedir()
   const claudeDir = join(home, ".claude")
+  const opencodeDir = join(home, ".config", "opencode")
   const cacheDir = join(claudeDir, "plugins", "cache")
   const marketplacesDir = join(claudeDir, "plugins", "marketplaces")
-  const targetDir = join(claudeDir, "skills")
+  const targetDir = join(opencodeDir, "skill")
 
   try {
-    // Check if Claude directory exists
+    // Check if Claude directory exists (required for plugin cache/marketplaces)
     if (!(await exists(claudeDir))) {
       (client as unknown as { app: { log: (msg: string) => void } }).app.log(
         "Claude Code not installed, skipping"
@@ -343,8 +344,8 @@ async function syncSkills(client: PluginInput["client"]): Promise<void> {
 /**
  * Claude Skill Sync Plugin
  *
- * Automatically discovers and syncs OpenCode plugin skills to the Claude Code
- * ~/.claude/skills directory via symlinks. Runs asynchronously to avoid blocking
+ * Automatically discovers and syncs OpenCode plugin skills to the OpenCode
+ * ~/.config/opencode/skill directory via symlinks. Runs asynchronously to avoid blocking
  * OpenCode startup.
  *
  * @example


### PR DESCRIPTION
## Summary

This is a critical fix for v1.0.1 release. The plugin was syncing skills to the wrong location.

### Changes
- Fixed skill sync target directory from `~/.opencode/skill` to `~/.config/opencode/skill`
- This aligns with the correct OpenCode configuration directory structure
- Makes the plugin functional in OpenCode environments

### Impact
Without this fix, synced skills are placed in an incorrect directory that OpenCode doesn't read from, making the plugin non-functional.